### PR TITLE
Respond with correct mime type

### DIFF
--- a/sandbox.py
+++ b/sandbox.py
@@ -23,6 +23,7 @@ import json
 import asyncio
 import hashlib
 import argparse
+import functools
 
 from aiohttp import web
 from asyncio.subprocess import PIPE
@@ -80,6 +81,7 @@ class EchoServer(asyncio.Protocol):
         # print('data received: {}'.format(data.decode()))
         self.transport.write(data)
 
+_pretty_dumps = functools.partial(json.dumps, sort_keys=True, indent=4)
 
 @asyncio.coroutine
 def api(request):
@@ -96,7 +98,7 @@ def api(request):
         except KeyboardInterrupt:
             pass
         ret['file_md5'] = file_md5
-        return web.Response(body=json.dumps(ret, sort_keys=True, indent=4).encode('utf-8'))
+        return web.json_response(ret, dumps=_pretty_dumps)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Use `web.json_response` instead of `web.Response`. This ensures the correct mime type `application/json` is set for the response.