### PR TITLE
Define stdout_value at the beginning of the function

### DIFF
--- a/sandbox.py
+++ b/sandbox.py
@@ -53,13 +53,13 @@ class PHPSandbox(object):
 
     @asyncio.coroutine
     def sandbox(self, script, phpbin="php7.0"):
+        self.stdout_value = b''
         if not os.path.isfile(script):
             raise Exception("Sample not found: {0}".format(script))
 
         try:
             cmd = [phpbin, "sandbox.php", script]
             self.proc = yield from asyncio.create_subprocess_exec(*cmd, stdout=PIPE)
-            self.stdout_value = b''
             yield from asyncio.wait_for(self.read_process(), timeout=3)
         except Exception as e:
             try:


### PR DESCRIPTION
This line
```
self.proc = yield from asyncio.create_subprocess_exec(*cmd, stdout=PIPE)
```
can cause the exception in phpox, in this case `stdout_value` will be undefined
```
serving on ('0.0.0.0', 8088)
Error executing the sandbox: [Errno 2] No such file or directory: 'php7.0': 'php7.0'
Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_protocol.py", line 406, in start
    resp = await task
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py", line 435, in _handle
    resp = await handler(request)
  File "sandbox.py", line 96, in api
    ret = yield from asyncio.wait_for(sb.sandbox(f.name, phpbin), timeout=10)
  File "/usr/lib/python3.6/asyncio/tasks.py", line 358, in wait_for
    return fut.result()
  File "sandbox.py", line 71, in sandbox
    return {'stdout': self.stdout_value.decode('utf-8')}
AttributeError: 'PHPSandbox' object has no attribute 'stdout_value'
```
It leads to exception in tanner https://github.com/mushorg/tanner/issues/286

Move  `stdout_value` to the beginning of the function, so in return statement it is defined.